### PR TITLE
Run `rails db:migrate`

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,53 +10,54 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161020115446) do
+ActiveRecord::Schema.define(version: 2019_02_17_185957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "blazer_audits", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "query_id"
-    t.text     "statement"
-    t.string   "data_source"
+    t.integer "user_id"
+    t.integer "query_id"
+    t.text "statement"
+    t.string "data_source"
     t.datetime "created_at"
   end
 
   create_table "blazer_checks", force: :cascade do |t|
-    t.integer  "creator_id"
-    t.integer  "query_id"
-    t.string   "state"
-    t.string   "schedule"
-    t.text     "emails"
-    t.string   "check_type"
-    t.text     "message"
+    t.integer "creator_id"
+    t.integer "query_id"
+    t.string "state"
+    t.string "schedule"
+    t.text "emails"
+    t.string "check_type"
+    t.text "message"
     t.datetime "last_run_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text "slack_channels"
   end
 
   create_table "blazer_dashboard_queries", force: :cascade do |t|
-    t.integer  "dashboard_id"
-    t.integer  "query_id"
-    t.integer  "position"
+    t.integer "dashboard_id"
+    t.integer "query_id"
+    t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "blazer_dashboards", force: :cascade do |t|
-    t.integer  "creator_id"
-    t.text     "name"
+    t.integer "creator_id"
+    t.text "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "blazer_queries", force: :cascade do |t|
-    t.integer  "creator_id"
-    t.string   "name"
-    t.text     "description"
-    t.text     "statement"
-    t.string   "data_source"
+    t.integer "creator_id"
+    t.string "name"
+    t.text "description"
+    t.text "statement"
+    t.string "data_source"
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
This updates the schema:
* adds `t.text "slack_channels"` to `blazer_checks`
* prevents rails from raising "You have 1 pending migration" error, for example when running `bin/setup`